### PR TITLE
Dev

### DIFF
--- a/.build/build.bat
+++ b/.build/build.bat
@@ -1,30 +1,36 @@
  @echo off
 setlocal
 
-set version=0.0.1
-set modbase=P:\inkihh\
-set modpath=
-set modname=AutolockVehicles
-set serverip=192.168.178.96
-set serverport=2302
-set password=inkihh
-set playername=inkihh
-::set modlist=@MuchCarKey;@VPPAdminTools;@Dabs Framework;@CF
-::set modlist=@TraderPlus;@VPPAdminTools;@Dabs Framework;@CF
-set modlist=@Trader;@VPPAdminTools;@Dabs Framework;@CF
-::set modlist=@DayZ-Expansion-Bundle;@DayZ-Expansion-Core;@DayZ-Expansion-Licensed;@VPPAdminTools;@Dabs Framework;@CF
+if not exist .\environment.bat (
+	echo No environment.bat found! Forgot to copy environment.bat.orig to environment.bat?
+	exit
+)
+
+call .\environment.bat
+
+set version=%env_version%
+set modbase=%env_modbase%
+set modpath=%env_modpath%
+set modname=%env_modname%
+set serverip=%env_serverip%
+set serverport=%env_serverport%
+set password=%env_password%
+set playername=%env_playername%
+set modlist=%env_modlist%
+set servermod=%env_servermod%
 set srcpath=%modbase%%modpath%%modname%
-set dayzclientpath=C:\Program Files (x86)\Steam\steamapps\common\DayZ
-set dayzserverpath=C:\Program Files (x86)\Steam\steamapps\common\DayZServer
-set buildpath=P:\mods\local
-set mission=dayzOffline.chernarusplus
-set keypath=C:\Users\ingma\OneDrive\Documents\Github\dayztools\keys\inkihh\inkihh
-set clientprofile=P:\mods\profiles\_dev\%mission%\client
-set serverprofile=P:\mods\profiles\_dev\%mission%\server
-set serverconfig=P:\mods\config\%mission%.dev.cfg
-set pboprojectpath=C:\Program Files (x86)\Mikero\DePboTools\bin\PboProject.exe
-set makepbopath=C:\Program Files (x86)\Mikero\DePboTools\bin\MakePbo.exe
-set signtoolpath=C:\Program Files (x86)\Steam\steamapps\common\DayZ Tools\Bin\DsUtils\DSsignfile.exe
+set dayzclientpath=%env_dayzclientpath%
+set dayzserverpath=%env_dayzserverpath%
+set serverparams=%env_serverparams%
+set buildpath=%env_buildpath%
+set mission=%env_mission%
+set keypath=%env_keypath%
+set clientprofile=%env_clientprofile%
+set serverprofile=%env_serverprofile%
+set serverconfig=%env_serverconfig%
+set pboprojectpath=%env_pboprojectpath%
+set makepbopath=%env_makepbopath%
+set signtoolpath=%env_signtoolpath%
 
 set dowipe=0
 
@@ -32,7 +38,7 @@ for /f "tokens=*" %%i in ('node .\modpath.js "%modlist%"') do set fullmodlist=%%
 
 ::goto :end
 
-set fullmodlist=%fullmodlist%;P:\mods\local\@LBmaster;P:\mods\local\@AutolockVehicles
+set fullmodlist=%fullmodlist%%env_modlistlocal%
 
 ::goto :nokill
 
@@ -149,23 +155,9 @@ echo .
 echo STARTING THE SERVER
 echo .
 cd /d "%dayzserverpath%"
-start "DayZServer" ".\DayZServer_x64.exe" /high "-port=%serverport%" "-dologs" "-netLog" "-adminlog" "-config=%serverconfig%" "-profiles=%serverprofile%"  "-scriptDebug=true" "-scrAllowFileWrite" "-equalmodrequired" "-mod=%fullmodlist%" "-servermod=P:\mods\serverside"
+start "DayZServer" ".\DayZServer_x64.exe" %serverparams% "-port=%serverport%" "-config=%serverconfig%" "-profiles=%serverprofile%"  "-mod=%fullmodlist%" "-servermod=%servermod%"
 ::goto :end
-::%buildpath%\@%modpath%%modname%
-::"-servermod=P:\mods\serverside"
-::"-servermod=%buildpath%\@%modpath%%modname%"
-::"-mod=%fullmodlist%" 
 
-goto :afterdzsalauncher
-
-echo -------------------------------------------------------
-echo .
-echo STARTING DZSALModServer
-echo .
-cd /d "%dayzserverpath%"
-start "DZSALModServer" ".\DZSALModServer.exe" "-port=%serverport%" "-mod=%fullmodlist%" "-skipserver" "-password=%password%"
-
-:afterdzsalauncher
 ::goto :eof
 
 TIMEOUT 20
@@ -177,13 +169,9 @@ echo .
 echo STARTING THE CLIENT
 echo .
 cd /d "%dayzclientpath%"
-start "DayZClient" ".\DayZ_BE.exe" "-dologs" "-nosplash" "-nopause" "-name=%playername%" "-nobenchmark" "-skipIntro" "-password=%password%" "-profiles=%clientprofile%" "-connect=%serverip%" "-port=%serverport%" "-mod=%fullmodlist%"
-::"-name=inkihh"
+start "DayZClient" ".\DayZ_BE.exe" %clientparams% "-name=%playername%" "-password=%password%" "-profiles=%clientprofile%" "-connect=%serverip%" "-port=%serverport%" "-mod=%fullmodlist%"
 
 :end
-:: @CHANGEME so that cmd goes back
-cd /d C:\Users\ingma\OneDrive\Documents\Github\dayztools\build
-
 GOTO :EOF
 
 :GetUnixTime

--- a/.build/environment.bat
+++ b/.build/environment.bat
@@ -1,0 +1,29 @@
+echo SETTING ENVIRONEMT
+
+set env_version=0.0.1
+set env_modbase=P:\inkihh\
+set env_modpath=
+set env_modname=AutolockVehicles
+set env_serverip=192.168.178.96
+set env_serverport=2302
+set env_password=inkihh
+set env_playername=inkihh
+::set modlist=@MuchCarKey;@VPPAdminTools;@Dabs Framework;@CF
+set env_modlist=@TraderPlus;@VPPAdminTools;@Dabs Framework;@CF
+::set env_modlist=@Trader;@VPPAdminTools;@Dabs Framework;@CF
+::set modlist=@DayZ-Expansion-Bundle;@DayZ-Expansion-Core;@DayZ-Expansion-Licensed;@VPPAdminTools;@Dabs Framework;@CF
+set env_servermod=P:\mods\serverside
+set env_modlistlocal=;P:\mods\local\@LBmaster;P:\mods\local\@AutolockVehicles
+set env_dayzclientpath=C:\Program Files (x86)\Steam\steamapps\common\DayZ
+set env_dayzserverpath=C:\Program Files (x86)\Steam\steamapps\common\DayZServer
+set env_clientparams="-dologs" "-nosplash" "-nopause" "-nobenchmark" "-skipIntro"
+set env_serverparams=/high "-dologs" "-netLog" "-adminlog" "-scriptDebug=true" "-scrAllowFileWrite" "-equalmodrequired"
+set env_buildpath=P:\mods\local
+set env_mission=dayzOffline.chernarusplus
+set env_keypath=C:\Users\ingma\OneDrive\Documents\Github\dayztools\keys\inkihh\inkihh
+set env_clientprofile=P:\mods\profiles\_dev\%env_mission%\client
+set env_serverprofile=P:\mods\profiles\_dev\%env_mission%\server
+set env_serverconfig=P:\mods\config\%env_mission%.dev.cfg
+set env_pboprojectpath=C:\Program Files (x86)\Mikero\DePboTools\bin\PboProject.exe
+set env_makepbopath=C:\Program Files (x86)\Mikero\DePboTools\bin\MakePbo.exe
+set env_signtoolpath=C:\Program Files (x86)\Steam\steamapps\common\DayZ Tools\Bin\DsUtils\DSsignfile.exe

--- a/.build/environment.bat.orig
+++ b/.build/environment.bat.orig
@@ -1,0 +1,25 @@
+ @echo off
+setlocal
+
+echo SETTING ENVIRONEMT
+
+echo Fill your values below and then comment this line and uncomment the following exit
+exit
+
+set env_serverip=
+set env_serverport=
+set env_password=
+set env_playername=
+set env_modlist=@VPPAdminTools;@Dabs Framework;@CF
+set env_modlistlocal=
+set env_dayzclientpath=
+set env_dayzserverpath=
+set env_buildpath=
+set env_mission=
+set env_keypath=
+set env_clientprofile=
+set env_serverprofile=
+set env_serverconfig=
+set env_pboprojectpath=
+set env_makepbopath=
+set env_signtoolpath=

--- a/.build/files/info.txt
+++ b/.build/files/info.txt
@@ -33,15 +33,18 @@ At first install, a configuration file with these default values will be created
 {
     "debug_log_level": 1,
     "use_key_mod": 0,
+    "enable_proximity_autolock": 0,
+    "enable_proximity_autounlock": 0,
     "enable_startup_autolock_timer": 0,
     "enable_disconnect_autolock_timer": 0,
-    "enable_proximity_autolock": 0,
     "enable_close_doors_on_autolock": 0,
     "enable_engine_off_on_autolock": 0,
     "lock_only_when_all_doors_are_closed": 1,
+	"lock_only_when_no_players_inside": 0,
     "autolock_delay_startup_minutes": 2,
     "autolock_delay_player_disconnect_minutes": 1,
-    "proximity_lock_distance_meters": 5
+    "proximity_lock_distance_meters": 5,
+    "proximity_unlock_distance_meters": 2
 }
 [/code]
 
@@ -91,14 +94,22 @@ If this feature is enabled, the mod will try to automatically lock the spawned v
 This feature will try to lock a vehicle when a player disconnects. It will only work on the last vehicle the player has unlocked, and only if they were the last player to unlock it. The setting that delays this action is [i]autolock_delay_player_disconnect_minutes[/i].
 
 [h3]enable_proximity_autolock[/h3]
-This works like handsfree locking in real life: If a player unlocks a vehicle and then later moves farther away from it than defined by [i]proximity_lock_distance_meters[/i], the mod will try to lock it. Again, this only works if they were the last player to unlock it.
+This works like handsfree locking in real life: If a player unlocks a vehicle and then later moves farther away from it than defined by [i]proximity_lock_distance_meters[/i], the mod will try to lock it. Again, this only works if they were the last player to unlock it. If they enter the proximity again, it will be tried to unlock it, with the same checks as locking.
 
 The constant distance measuring happens in the player's client, so it won't affect the server's performance.
+
+[h3]enable_proximity_autounlock[/h3]
+
+Same as above, but unlock. Notice that different proximities can be configured for lock or unlock.
 
 [h3]lock_only_when_all_doors_are_closed[/h3]
 Some locking mechanisms behave in an unexpoected way if the doors are being programmatically locked while one or more doors are open. With this setting, you can determine that autolocking will only happen if all doors are closed, including the trunk.
 
 This can also be helpful for groups of players that work on a shared vehicle at a trader location, so that their vehicle doesn't get locked if the player that last locked it runs to sell.
+
+[h3]lock_only_when_no_players_inside[/h3]
+
+If set to 1, the mod will check if passengers are in the vehicle, right before locking, and if so, don't lock it.
 
 [h3]enable_engine_off_on_autolock[/h3]
 [h3]enable_close_doors_on_autolock[/h3]

--- a/scripts/4_World/AutolockVehicles_Settings.c
+++ b/scripts/4_World/AutolockVehicles_Settings.c
@@ -2,15 +2,18 @@ class AutolockVehicles_Settings
 {
 	int debug_log_level = 1;
 	int use_key_mod = 0;
+	int enable_proximity_autolock = 0;
+	int enable_proximity_autounlock = 0;
 	int enable_startup_autolock_timer = 0;
 	int enable_disconnect_autolock_timer = 0;
-	int enable_proximity_autolock = 0;
 	int enable_close_doors_on_autolock = 0;
 	int enable_engine_off_on_autolock = 0;
 	int lock_only_when_all_doors_are_closed = 1;
+	int lock_only_when_no_players_inside = 0;
 	int autolock_delay_startup_minutes = 2;
 	int autolock_delay_player_disconnect_minutes = 1;
 	int proximity_lock_distance_meters = 5;
+	int proximity_unlock_distance_meters = 1;
 	
 	[NonSerialized()]
 	private bool m_IsLoaded;

--- a/scripts/4_World/Entities/modded/PlayerBase.c
+++ b/scripts/4_World/Entities/modded/PlayerBase.c
@@ -5,7 +5,9 @@ modded class PlayerBase extends ManBase
 	#endif
 
 	CarScript m_AutolockVehicles_LastUnlockedVehicle;
+
 	int m_AutolockVehicles_proximity_lock_distance_meters;
+	int m_AutolockVehicles_proximity_unlock_distance_meters;
 
 	#ifdef SERVER
 		override void OnDisconnect()
@@ -43,11 +45,12 @@ modded class PlayerBase extends ManBase
 			{
 				if(!GetGame().IsClient()) return;
 
-				Param2<string, int> carParam;
+				Param3<string, int, int> carParam;
 				if (!ctx.Read(carParam)) return;
 
 				string persistentId = carParam.param1;
 				m_AutolockVehicles_proximity_lock_distance_meters = carParam.param2;
+				m_AutolockVehicles_proximity_unlock_distance_meters = carParam.param3;
 				
 				array<Object> objects_around = new array<Object>;
 				GetGame().GetObjectsAtPosition(GetPosition(), 10, objects_around, NULL);
@@ -74,7 +77,13 @@ modded class PlayerBase extends ManBase
 			{
 				if(!GetGame().IsServer()) return;
 
-				AutolockVehicles_App.GetInstance().m_Logger.Log("[AutolockVehicles] AutolockVehicles_RPC.LOCK_PROXIMITY");
+				AutolockVehicles_App.GetInstance().m_Logger.Log("[PlayerBase.OnRPC] AutolockVehicles_RPC.LOCK_PROXIMITY");
+
+				if(!AutolockVehicles_App.GetInstance().m_Settings.enable_proximity_autolock)
+				{
+					AutolockVehicles_App.GetInstance().m_Logger.Log("[PlayerBase.OnRPC] enable_proximity_autolock not set, exiting");
+					return;
+				}
 
 				player = PlayerBase.Cast(sender.GetPlayer());
 				if(!player) return;
@@ -89,7 +98,13 @@ modded class PlayerBase extends ManBase
 			{
 				if(!GetGame().IsServer()) return;
 
-				AutolockVehicles_App.GetInstance().m_Logger.Log("[AutolockVehicles] AutolockVehicles_RPC.UNLOCK_PROXIMITY");
+				AutolockVehicles_App.GetInstance().m_Logger.Log("[PlayerBase.OnRPC] AutolockVehicles_RPC.UNLOCK_PROXIMITY");
+
+				if(!AutolockVehicles_App.GetInstance().m_Settings.enable_proximity_autounlock)
+				{
+					AutolockVehicles_App.GetInstance().m_Logger.Log("[PlayerBase.OnRPC] enable_proximity_autounlock not set, exiting");
+					return;
+				}
 
 				player = PlayerBase.Cast(sender.GetPlayer());
 				if(!player) return;

--- a/scripts/5_Mission/classes/modded/MissionGameplay.c
+++ b/scripts/5_Mission/classes/modded/MissionGameplay.c
@@ -28,7 +28,7 @@ modded class MissionGameplay
 			player.RPCSingleParam(AutolockVehicles_RPC.LOCK_PROXIMITY, null, true);
 		}
 
-		if(distanceBetweenOwnerAndVehicle < player.m_AutolockVehicles_proximity_lock_distance_meters && wasProximityLocked)
+		if(distanceBetweenOwnerAndVehicle < player.m_AutolockVehicles_proximity_unlock_distance_meters && wasProximityLocked)
 		{
 			car.m_AutolockVehicles_WasProximityLocked = false;
 		   


### PR DESCRIPTION
## Added/Changed

- AutoLock and AutoUnlock can now be configured separately.
- It can now configured to autolock the vehicle only if no players inside.
- Lowered loglevel of some logging from DEBUG to NOTICE.

## New parameters

### enable_proximity_autounlock

Set to 1 to enable unlocking a vehicle when entering its proximity, if the player was the latest to unlock it, and it was the latest vehicle the player unlocked.

### proximity_unlock_distance_meters

It is recommended to not set this parameter lower than 2, or it may not register.
